### PR TITLE
[FEAT] 메인 페이지 nickname api 추가

### DIFF
--- a/src/shared/api/authHandlers.ts
+++ b/src/shared/api/authHandlers.ts
@@ -1,0 +1,71 @@
+import axios, {
+  type AxiosInstance,
+  type InternalAxiosRequestConfig,
+} from "axios";
+import { useAuthStore } from "../store";
+
+type MemberResponse = {
+  status: number;
+  code: string;
+  message: string;
+  data: {
+    id: number;
+    nickname: string;
+    role: string;
+    totalWalkCount: number;
+    totalDistance: number;
+  };
+};
+
+export const createAuthHandlers = (memberClient: AxiosInstance) => {
+  let profileHydrated = false;
+
+  const withAuthHeader = async (config: InternalAxiosRequestConfig) => {
+    const token = localStorage.getItem("accessToken");
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+
+      if (!profileHydrated && !useAuthStore.getState().profile) {
+        profileHydrated = true;
+        try {
+          const { data } = await memberClient.get<MemberResponse>("/member");
+          const { id, nickname, totalWalkCount, totalDistance } = data.data;
+          useAuthStore
+            .getState()
+            .setProfile({
+              memberId: id,
+              nickName: nickname,
+              totalWalkCount,
+              totalDistance,
+            });
+        } catch (error) {
+          console.error("사용자 정보를 불러오지 못했습니다.", error);
+        }
+      }
+    }
+    return config;
+  };
+
+  const handleAuthError = (error: unknown) => {
+    if (!axios.isAxiosError<{ code?: string }>(error)) {
+      return Promise.reject(error);
+    }
+
+    const res = error.response;
+    const data = res?.data;
+
+    if (!res) return Promise.reject(error);
+
+    const isOnLoginPage = window.location.pathname.startsWith("/login");
+
+    if (res.status === 401 && data?.code === "ATH-010" && !isOnLoginPage) {
+      localStorage.removeItem("accessToken");
+      useAuthStore.getState().clearProfile();
+      window.location.replace("/login");
+    }
+
+    return Promise.reject(error);
+  };
+
+  return { withAuthHeader, handleAuthError };
+};


### PR DESCRIPTION
## 📄 작업 내용 요약
`client.ts` 폴더 내부 토큰 유효 검사 핸들러 분리 및 authstore 내부 값 갱신 로직 추가
## 문제 상황
새로고침 시 `AuthStore` 내부 값이 사라져 메인 페이지의 닉네임 부분이 보이지 않는 문제 발생
## 해결 방안
매 새로고침 마다 `/v1/member` API를 호출하여 store 값을 갱신하여 문제 해결
## 📎 Issue #14 